### PR TITLE
DEFINES_FT: `sed -i` is not portable; use a tmp file

### DIFF
--- a/configure/E3/DEFINES_FT
+++ b/configure/E3/DEFINES_FT
@@ -3,7 +3,7 @@ E3_CROSS_COMPILER_TARGET_ARCHS ?=
 
 define git_update =
 git submodule deinit -f $@/
-sed -i '/submodule/,24465d'  $(TOP)/.git/config
+sed '/submodule/,24465d'  $(TOP)/.git/config >/tmp/$$ && mv -f /tmp/$$ $(TOP)/.git/config
 rm -rf $(TOP)/.git/modules/$@
 git submodule init $@/
 git submodule update --init --recursive $@/
@@ -13,7 +13,7 @@ endef
 
 define git_base_update =
 git submodule deinit -f $@/
-sed -i '/submodule/,$$d'  $(TOP)/.git/config	
+sed '/submodule/,$$d'  $(TOP)/.git/config >/tmp/$$ && mv -f /tmp/$$ $(TOP)/.git/config
 git submodule init $@/
 git submodule update --init --recursive $@/
 endef


### PR DESCRIPTION
Allow the scripts to be run with a "POSIX" version of sed.
The "-i" option is not available under POSIX, it is a GNU extension,
typically avalailable under Linux but not under e.g. MacOS