### PR TITLE
Minor fix for OSX

### DIFF
--- a/configure/E3/DEFINES_FT
+++ b/configure/E3/DEFINES_FT
@@ -11,9 +11,9 @@ git submodule update --remote --merge $@/
 endef
 
 
-define git_base_update =
+define git_base_update
 git submodule deinit -f $@/
-sed -i '/submodule/,$$d'  $(TOP)/.git/config	
+sed -i='' '/submodule/,$$d'  $(TOP)/.git/config	
 git submodule init $@/
 git submodule update --init --recursive $@/
 endef


### PR DESCRIPTION
This minor fix makes it possible to compile e3-base under MacOSX and should have no (as far as I can tell) negative effects when building under Linux.